### PR TITLE
remove hardcoded links

### DIFF
--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -75,7 +75,7 @@ In order to effectively support and manage the diverse needs of the community, w
 
 ## Key Artifacts
 
-See [Artifacts](https://www.cloudnativeplatforms.com/artifacts/) for a list of key artifacts produced by the community. These include whitepapers, presentations, and other resources that are useful for practitioners and organizations looking to build and operate cloud native platforms.
+See [Artifacts](/artifacts/) for a list of key artifacts produced by the community. These include whitepapers, presentations, and other resources that are useful for practitioners and organizations looking to build and operate cloud native platforms.
 
 ## Active Initiatives
 

--- a/website/content/en/contribute/community-post-guidelines/index.md
+++ b/website/content/en/contribute/community-post-guidelines/index.md
@@ -6,7 +6,7 @@ weight: 100 # Makes sure this sorts to the top of the list always
 
 ## Introduction
 
-This policy outlines the guidelines for accepting, reviewing, and publishing blog posts on our platform: https://www.cloudnativeplatforms.com/blog.
+This policy outlines the guidelines for accepting, reviewing, and publishing blog posts on our community platform: [blog](/blog)
 
 Blog posts are an opportunity to foster a diverse and vibrant discussion environment, showcasing a variety of viewpoints from members and the wider open source community.
 

--- a/website/content/en/contribute/ways-to-contribute/_index.md
+++ b/website/content/en/contribute/ways-to-contribute/_index.md
@@ -6,4 +6,4 @@ description: This is a list of specific opportunities to get involved.
 
 Community projects are tracked in [GitHub Issues](https://github.com/Cloud-Native-Platform-Engineering/cnpe-community/issues). Please start there for any current projects and to propose any new projects.
 
-This section contains some of the ongoing contribution opportunities which do not map to a current open issue. Keep in mind, this is not an exhaustive list so if you do not see something for you here or in the GitHub Issues, that is ok! Just follow the other options on the [contribute main page](https://www.cloudnativeplatforms.com/contribute/).
+This section contains some of the ongoing contribution opportunities which do not map to a current open issue. Keep in mind, this is not an exhaustive list so if you do not see something for you here or in the GitHub Issues, that is ok! Just follow the other options on the [contribute main page](/contribute/).

--- a/website/content/en/contribute/ways-to-contribute/platform-maturity-model-examples/index.md
+++ b/website/content/en/contribute/ways-to-contribute/platform-maturity-model-examples/index.md
@@ -21,7 +21,7 @@ The intention of these contributions is to make these examples more grounded in 
 
 ## Contributing
 
-To get started, review [the current model](https://www.cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/) are scroll down to the `Model Detail` section. In this section there is a page per aspect, and each level provides `Example Scenario` section (e.g. [Investment Provisional level](https://www.cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/#example-scenarios)).
+To get started, review [the current model](/whitepapers/platform-eng-maturity-model/) are scroll down to the `Model Detail` section. In this section there is a page per aspect, and each level provides `Example Scenario` section (e.g. [Investment Provisional level](/whitepapers/platform-eng-maturity-model/#example-scenarios)).
 
 We are asking for community members to please open a [Pull Request (PR)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) adding your example to the current model version. PRs should be limited to just examples, as other changes such as vocabulary, content, or even formatting of the wider maturity model can be submitted as a separate issue.
 


### PR DESCRIPTION
This removes hardcoded links and replaces (most of them) with relative references.
There is still work to do to replace older tag-app-delivery links, but this PR is not intended for that.