### PR TITLE
Change the base URL to a working URL

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://cloudnativeplatforms.com/"
-title = "Cloud Native Platform Engineering Community"
+title = "CNCF Cloud Native Platform Engineering Technical Community Group"
 
 # Language settings
 contentDir = "content/en"


### PR DESCRIPTION
The baseURL of https://cloud-native-platform.com doesn't seem to work and it is pre-pended to various links on the website.  I believe the correct URL needs to have the dashes removed.