### PR TITLE
Update PDF link to latest version

### DIFF
--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -1,6 +1,6 @@
 ---
 title:  "CNCF Platforms White Paper"
-pdf: https://github.com/Cloud-Native-Platform-Engineering/cnpe-community/raw/main/platforms-whitepaper/latest/assets/platforms-def-v1.0.pdf
+pdf: https://github.com/Cloud-Native-Platform-Engineering/cnpe-community/raw/main/platforms-whitepaper/latest/assets/platforms-def-latest.pdf
 version_info: https://github.com/Cloud-Native-Platform-Engineering/cnpe-community/tree/main/platforms-whitepaper/README.md
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers


### PR DESCRIPTION
The mix of latest and 1.0 was causing a 404 error.

```
1 / 252 requests
130 kB / 584 kB transferred
265 kB / 14,489 kB resources
Finish: 6.80 s
DOMContentLoaded: 1.47 s
Request URL: https://github.com/Cloud-Native-Platform-Engineering/cnpe-community/raw/main/platforms-whitepaper/latest/assets/platforms-def-v1.0.pdf
Request Method: GET
Status Code: 404 Not Found
Remote Address: 20.26.156.215:443
Referrer Policy: strict-origin-when-cross-origin
```

With a bit of digging, I wonder if it should be platforms-def-latest.pdf rather than platforms-def-1.0.pdf?