### PR TITLE
Add blog: From Automation to Governed Execution

### DIFF
--- a/website/content/en/blog/2026-07-02-automation-to-governed-execution.md
+++ b/website/content/en/blog/2026-07-02-automation-to-governed-execution.md
@@ -1,0 +1,114 @@
+---
+title: "From Automation to Governed Execution: Closing the Operating Model Gap in Platform Engineering"
+slug: automation-to-governed-execution
+date: 2026-07-02 12:00:00 +0000
+author: Jeleel Muibi
+categories:
+- Article
+tags:
+- Platform Engineering
+- Community Contributions
+---
+
+Many infrastructure teams can run automation before they can explain the operating model around it.
+
+They may have Terraform modules, Ansible playbooks, CI/CD pipelines, Kubernetes clusters, cloud accounts, source-of-truth data and monitoring dashboards. Each tool can be valuable on its own. But when the tools become the primary operating interface, several questions remain harder than they should be:
+
+- Who or what decides that a change should run now?
+- Which system contains the authoritative intent?
+- What is validated before execution begins?
+- What evidence is kept after the change completes?
+- How does the team recover when the expected outcome does not happen?
+
+This is the gap between automation and governed execution. Automation makes an action repeatable. Governed execution makes the action understandable, controlled and recoverable as part of an operating model.
+
+## Tools Are Not the Operating Model
+
+Infrastructure automation often starts from a useful place: remove manual repetition, reduce drift and make changes easier to reproduce.
+
+The problem appears when teams expose the underlying tools directly as the main interface for operators and platform users. A request becomes a pipeline run. A recovery action becomes a playbook invocation. A platform workflow becomes a sequence of commands that someone has to remember, translate and execute in the right order.
+
+That may work while the environment is small and the same person understands every layer. It becomes fragile as more people, teams, environments and failure modes are added.
+
+Platform engineering should reduce that cognitive burden. A platform does not have to hide all complexity, but it should present the right complexity at the right level. The user should not need to reconstruct the operating model from tool names and repository paths.
+
+## Four Boundaries That Help
+
+One practical way to reason about governed execution is to separate four concerns:
+
+1. **Intent**: the desired state, request or operating outcome.
+2. **Execution**: the controlled action that changes or checks the system.
+3. **Governance**: the rules, validations, approvals and constraints around execution.
+4. **Implementation**: the replaceable tools, modules, scripts and providers that perform the work.
+
+These boundaries are not a new product category. They are a design discipline.
+
+If intent and implementation are mixed together, every workflow becomes tightly coupled to a specific tool. If governance is buried inside scripts, it becomes hard to review and harder to explain. If execution produces no durable record, the team loses evidence when it needs to audit, debug or recover.
+
+Separating these concerns gives platform teams a better language for design decisions. It also helps platform users understand what they are asking the platform to do.
+
+## Source of Truth as an Operating Input
+
+A source of truth is often introduced as a documentation improvement. That is useful, but incomplete.
+
+For governed execution, source-of-truth data should become an operating input. It can describe which environments exist, which services belong to which owners, which network prefixes are assigned, which recovery targets apply, and which constraints must be respected before a change runs.
+
+The platform can then consume that intent and use it to shape execution. Instead of asking an operator to remember the right inventory, variables and runtime context, the workflow can derive those inputs from a shared model.
+
+This does not remove the need for engineering judgement. It makes the judgement more explicit. The question moves from "which command do I run?" to "is this intent correct, valid and authorised for this environment?"
+
+## Recovery Evidence Is a Platform Capability
+
+Recovery is often treated as something separate from platform engineering. In practice, recovery is one of the strongest tests of the operating model.
+
+If a team cannot show what was requested, what ran, what passed validation, what failed, who approved the action and what state was restored, then recovery depends too heavily on memory and informal coordination.
+
+Recovery evidence does not need to be complicated at first. A useful record can include:
+
+- the requested action
+- the source-of-truth inputs used
+- validation results
+- approval or decision point
+- execution output
+- recovery time or outcome
+- follow-up actions
+
+The important point is that evidence is designed into the workflow rather than reconstructed after an incident.
+
+## A Small-Team Starting Point
+
+Small teams do not need to build a large internal platform before they can apply this pattern.
+
+A practical starting point is to choose one recurring workflow and describe it in terms of intent, execution, governance and implementation. For example:
+
+- Provision a shared environment.
+- Promote a database replica.
+- Rotate an infrastructure secret.
+- Recover a service after a failed deployment.
+- Register a network prefix before automation consumes it.
+
+For that workflow, define:
+
+- where intent is recorded
+- what validations must pass
+- who can approve or trigger the action
+- what automation is allowed to run
+- what evidence is stored after completion
+
+That single workflow becomes a seed for a more mature operating model. It gives the team something concrete to improve, discuss and hand over.
+
+## Keeping the Pattern Tool-Neutral
+
+The pattern does not depend on a specific platform, cloud provider or automation toolchain. A team could apply it with different source-of-truth systems, CI/CD tools, workflow engines, infrastructure automation frameworks or cloud-native control planes.
+
+The useful lesson is that infrastructure workflows become easier to operate when the operating model is visible. The platform team can change implementation details over time while keeping intent, governance, execution and evidence understandable to the people who rely on the platform.
+
+## Conclusion
+
+Automation answers the question: can this action be repeated?
+
+Governed execution asks additional questions: should it run, under what conditions, from which source of truth, with which validation, and with what evidence afterwards?
+
+That difference matters for platform engineering. A platform is not only a set of tools behind an interface. It is a way of making technical capabilities safer, clearer and more useful for the people who depend on them.
+
+The next step for many teams is therefore not simply more automation. It is a better operating model around the automation they already have.


### PR DESCRIPTION
## Summary

This adds a community blog contribution about the operating-model gap between infrastructure automation and governed execution.

The post discusses:

- separating intent, execution, governance and implementation
- using source-of-truth data as an operating input
- preserving recovery evidence for audit, reliability and handover
- applying the pattern incrementally in small teams

The article is deliberately tool-neutral and focuses on the operating model rather than a specific product, vendor or implementation.