### PR TITLE
Add blog: When to Fail Over

### DIFF
--- a/website/content/en/blog/2026-07-02-when-to-fail-over-governance-model.md
+++ b/website/content/en/blog/2026-07-02-when-to-fail-over-governance-model.md
@@ -1,0 +1,256 @@
+---
+title: "When to Fail Over: A Governance Model for Disaster Recovery"
+slug: when-to-fail-over-governance-model
+date: 2026-07-02 12:00:00 +0000
+author: Jeleel Muibi
+categories:
+- Article
+tags:
+- Platform Engineering
+- Community Contributions
+- Disaster Recovery
+- Governance
+---
+
+> *This blog post represents the viewpoint of its author and does not necessarily reflect an official position or perspective of the Cloud Native Platform Engineering Community or any subsidiary working group.*
+
+# When to Fail Over: A Governance Model for Disaster Recovery
+
+Disaster recovery is often discussed as if it were mainly a technical discipline. Build the standby environment, configure replication, document failover, test the process, and the job is largely done. If the primary system fails, the recovery target takes over. The topic is framed as one of topology, tooling, replication, and automation.
+
+All of those things matter. None of them answers the hardest operational question: when should recovery actually be invoked?
+
+That question sounds deceptively simple. In practice it sits at the center of many recovery failures. Not because the standby is missing, or because replication was not configured, but because the organization has not defined who is allowed to decide, what evidence they should rely on, how much automation should act without human approval, and what record should exist after the decision is made.
+
+The technical problem of recovery is usually visible. The governance problem often stays hidden until the first time the organization has to choose between tolerating a degraded state and executing a disruptive failover. At that moment the team discovers that the recovery system is technically correct but operationally under-specified.
+
+## Why recovery decisions are hard
+
+The most dangerous recovery decisions are rarely the obvious ones.
+
+If a primary database server is unquestionably gone for thirty minutes, the case for failover is strong. The signals are consistent, the impact is material, and delaying the decision is itself harmful. Most organizations can align around that scenario.
+
+The trouble comes from ambiguous conditions:
+
+- a network partition that makes a primary appear unreachable from one segment but not another
+- replication lag that spikes beyond the normal threshold for several minutes
+- partial application failure that looks like an infrastructure outage
+- cloud connectivity degradation that affects part of the stack but not all of it
+
+In these cases, the recovery target may be healthy and the automation may be ready, but whether failover is the right action is not purely a technical conclusion. The decision depends on context:
+
+- How long has the degradation lasted?
+- Is the signal trustworthy?
+- What is the blast radius of switching now?
+- What operational or financial cost will the failover impose?
+- Is the failback path well understood if this turns out to be the wrong call?
+
+The more realistic the recovery design, the more it has to acknowledge that these are governance questions.
+
+## Why automatic failover is attractive
+
+Automatic failover is attractive for good reasons.
+
+It removes delay during outages. It avoids the need for an operator to wake up, authenticate, assess the situation, and approve an action while production remains degraded. It also reduces the chance that the right response is simply missed because the relevant person did not see the alert in time.
+
+For a narrow class of failures, automatic action is absolutely the right answer. If the organization has high confidence in the signal, a high-confidence standby target, and a well-rehearsed failback process, then forcing every such decision through human approval can become unnecessary friction.
+
+But the appeal of automation sometimes hides a deeper assumption: that the condition being detected is sufficient to justify the action being executed.
+
+That assumption is often too weak.
+
+## Where automatic failover breaks down
+
+Automatic failover systems are only as good as the signals and thresholds they trust. If those signals are incomplete, ambiguous, or decontextualized, the automation can make a fast and technically consistent decision that is still wrong.
+
+Consider a few common cases.
+
+### Network partitions
+
+A primary may be healthy but temporarily unreachable from the observer that evaluates failover conditions. If the system promotes a standby on that basis, the organization has created a split-brain risk out of what may have been a transient connectivity issue.
+
+### Replication lag spikes
+
+A temporary backlog can look like replication distress severe enough to justify role changes. If the spike resolves naturally a few minutes later, the failover was unnecessary and may have introduced additional recovery work with no meaningful benefit.
+
+### Cascading application alerts
+
+An application defect can generate symptoms that resemble platform distress. In poorly differentiated monitoring systems, the recovery engine sees a severe service problem and responds with infrastructure movement, even though the infrastructure was not the root cause.
+
+### Cost-opaque recovery targets
+
+Cloud-based standby environments often have a materially different cost posture once traffic is redirected to them. If a recovery system ignores that cost dimension completely, it may make decisions that are technically valid but operationally expensive in ways leadership would have weighed differently if the cost context were visible.
+
+The point is not that automatic failover is inherently unsafe. It is that failover decisions often encode business and operational trade-offs, not just technical thresholds.
+
+## Recovery needs a decision model
+
+A stronger design treats disaster recovery as a governed decision system.
+
+The signals are still gathered automatically. Health probes still run continuously. Replication lag is still measured. Connectivity, write readiness, application health, and endpoint availability are still monitored. The difference is what happens next.
+
+Instead of turning every failing signal directly into a state transition, the platform evaluates whether the condition meets a declared decision policy.
+
+That policy typically distinguishes between at least three modes:
+
+- **automatic**: the condition is severe and unambiguous enough that the platform should act immediately
+- **governed**: the condition is serious but still benefits from human approval
+- **informational**: the condition should raise visibility but should not initiate recovery
+
+This sounds straightforward, but the act of defining those modes forces useful architectural discipline. Teams must decide in advance which classes of condition justify immediate action and which ones require human judgment. That is precisely the governance work many recovery plans skip.
+
+## Signals should inform a decision surface
+
+One practical pattern is to route recovery signals into a decision surface rather than directly into the recovery engine.
+
+That surface presents:
+
+- the failed checks
+- the duration of the condition
+- the current health of the standby
+- any relevant latency or replication information
+- recent cost posture or traffic posture indicators
+- the proposed action
+
+For example:
+
+```text
+[signals] primary_health_probe: FAIL for 126s
+[signals] replication_lag: 0.8s
+[signals] standby_write_check: PASS
+[signals] application_error_rate: elevated
+[decision] failover candidate detected
+[mode] governed
+[action] promote standby and redirect application traffic
+[await] operator approval required
+```
+
+Under this model, the platform does not stop automating. It automates collection, evaluation, normalization, and recommendation. The human decision-maker is not inspecting ten dashboards and improvising under pressure. They are making a bounded decision using a prepared operational surface.
+
+That is a much stronger use of automation than simply letting threshold breaches drive everything directly.
+
+## Evidence should exist before and after approval
+
+If recovery is a governed process, then the organization should be able to explain not only what action was taken, but why it was taken.
+
+That means the decision path needs evidence. At minimum:
+
+- which conditions triggered evaluation
+- which thresholds were met
+- who approved the action, if approval was required
+- what standby target was selected
+- which verification probes passed after execution
+
+This is where disaster recovery becomes auditable rather than anecdotal.
+
+Instead of "the team failed over around 2am because prod looked bad," the organization has a concrete record:
+
+- the primary failed a health probe for a defined duration
+- replication lag remained within the acceptable range for promotion
+- the standby accepted writes successfully
+- the named approver confirmed the action at a specific time
+- the application reconnected successfully after endpoint change
+
+That record matters operationally, not just for compliance. It makes later review possible. It allows teams to refine thresholds. It turns recovery from a dramatic one-off into a process the organization can examine and improve.
+
+## Cost posture is part of recovery posture
+
+One under-modeled part of disaster recovery is cost.
+
+A failover from an on-prem primary to a cloud standby may change:
+
+- traffic egress costs
+- storage costs
+- managed service billing mode
+- data transfer paths
+- the amount of paid standby time consumed
+
+Most DR documentation mentions this at design time and then omits it from runtime decision-making. But operators frequently need that information while deciding, not after the monthly bill arrives.
+
+This does not mean cost should block recovery. If the organization is in a real outage, service continuity is usually worth the cost. But cost is still a recovery signal. It helps frame whether the current condition is severe enough to justify the change, whether the team should stay in the recovery target for hours or days, and whether a degraded mode is temporarily preferable to a full cutover.
+
+The broader point is that recovery posture is not only about technical survivability. It is about service, risk, and economics together.
+
+## Failback is part of the same governance system
+
+Many recovery plans are much stronger on failover than on failback.
+
+That is understandable. The emotional center of DR planning is usually the outage itself. The organization wants confidence that it can get to the standby target quickly. But in many architectures, especially hybrid ones, the failback path is the more complicated part:
+
+- data must be reconciled
+- replication direction may need to be reversed
+- DNS or routing may need to be moved back
+- application dependencies may need to be restored to their original location
+
+Failback also involves governance decisions. When is it safe to return? What evidence shows that the primary environment is ready again? Who approves the reversal? How is the duration on the temporary target evaluated?
+
+If failover is governed but failback is improvised, the recovery design is incomplete.
+
+## What an operationally mature DR model includes
+
+A mature recovery model usually has explicit answers to the following:
+
+### Decision classes
+
+Which conditions are automatic, which are governed, and which are informational?
+
+### Threshold definitions
+
+What exact signal combinations trigger evaluation? A useful threshold is specific, measurable, and time-bound.
+
+### Evidence schema
+
+What gets recorded about the condition, the decision, and the post-action verification?
+
+### Approval boundaries
+
+Who can authorize which classes of recovery?
+
+### Recovery verification
+
+What probes must pass before the organization treats the standby as live?
+
+### Return path
+
+How is failback evaluated, approved, and evidenced?
+
+None of this requires unusual tooling. The challenge is not tool availability. It is the discipline to define the operational contract around the recovery process.
+
+## A practical adoption path
+
+Teams that want to improve their current DR model do not need to replace everything at once. A more practical path is:
+
+1. Pick one recovery workflow. Database promotion is often a good candidate because it has clear signals and clear business impact.
+
+2. Define evaluation thresholds. Move from vague conditions like "primary unhealthy" to explicit conditions like "health probe failed for 120 consecutive seconds."
+
+3. Decide which scenarios are automatic and which are governed. Make the distinction explicit.
+
+4. Capture the evidence. Record the signal state, the decision mode, the approver if any, and the verification results.
+
+5. Rehearse failback as well as failover. Recovery that only works in one direction is not operationally complete.
+
+The common failure mode is assuming that DR maturity comes from adding more automation. Often it comes from adding better decision structure around the automation that already exists.
+
+## The point is not less automation
+
+Treating disaster recovery as a governance system does not mean removing automation from recovery. It means putting automation in the right places.
+
+Automation is excellent at:
+
+- gathering signals
+- normalizing health data
+- evaluating thresholds
+- performing deterministic execution steps
+- recording outcomes
+
+Humans are still needed for:
+
+- resolving ambiguous conditions
+- weighing service impact against operational and business cost
+- deciding when a disruption is severe enough to justify a cutover
+- approving return to the original state when recovery was temporary
+
+The best recovery designs are not the ones that replace all human involvement. They are the ones that make both the automated and human parts of the process explicit, repeatable, and reviewable.
+
+That is why disaster recovery is not only a technical discipline. It is also a governance discipline, and organizations that model it that way tend to recover more deliberately and more reliably.


### PR DESCRIPTION
## Summary

This adds a community blog contribution about treating disaster recovery as a governed decision system rather than only a failover automation problem.

The post discusses:

- why recovery decisions are often governance decisions, not only technical thresholds
- where automatic failover can break down under ambiguous signals
- using automatic, governed and informational decision modes
- routing recovery signals into a decision surface
- preserving recovery evidence before and after approval
- treating failback as part of the same operational contract

The article is tool-neutral and focuses on platform operations, recovery governance and operational maturity rather than a specific product, vendor or implementation.