### PR TITLE
Feat/update version switcher to simplify logic

### DIFF
--- a/platforms-maturity-model/latest/index.md
+++ b/platforms-maturity-model/latest/index.md
@@ -8,6 +8,9 @@ This document refers to, enhances, and follows similar standards as the followin
 [Platforms Definition White Paper](/whitepapers/platforms/)"
 type: whitepapers
 url: whitepapers/platform-eng-maturity-model
+# Version label override, shown in every language.
+# Uncomment when a version number is ready to be specified.
+# version_label: v1.1 (latest)
 ---
 
 

--- a/platforms-maturity-model/latest/index.md
+++ b/platforms-maturity-model/latest/index.md
@@ -8,12 +8,6 @@ This document refers to, enhances, and follows similar standards as the followin
 [Platforms Definition White Paper](/whitepapers/platforms/)"
 type: whitepapers
 url: whitepapers/platform-eng-maturity-model
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-    active: true
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
 ---
 
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -10,12 +10,6 @@ type: whitepapers
 url: whitepapers/platform-eng-maturity-model/v1/
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---
 
 

--- a/platforms-wg/glossary/latest/index.md
+++ b/platforms-wg/glossary/latest/index.md
@@ -3,12 +3,6 @@ title: Glossary
 description: "Defines key terms used in the Platforms Working Group's writings."
 type: whitepapers
 url: resources/glossary
-versions:
-  - url: /resources/glossary/
-    version: latest
-    active: true
-  - url: /resources/glossary/v1/
-    version: v1
 ---
 
 See also: [Cloud Native Glossary](https://glossary.cncf.io/)

--- a/platforms-wg/glossary/latest/index.md
+++ b/platforms-wg/glossary/latest/index.md
@@ -3,6 +3,9 @@ title: Glossary
 description: "Defines key terms used in the Platforms Working Group's writings."
 type: whitepapers
 url: resources/glossary
+# Version label override, shown in every language.
+# Uncomment when a version number is ready to be specified.
+# version_label: v1.1 (latest)
 ---
 
 See also: [Cloud Native Glossary](https://glossary.cncf.io/)

--- a/platforms-wg/glossary/v1/index.md
+++ b/platforms-wg/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 toc_hide: true
 list_pages: false
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 See also: [Cloud Native Glossary](https://glossary.cncf.io/)

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -5,7 +5,7 @@ version_info: https://github.com/Cloud-Native-Platform-Engineering/cnpe-communit
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers
 url: whitepapers/platforms
-# Version switcher label, shown in every language.
+# Version label override, shown in every language.
 version_label: v1.1 (latest)
 ---
 

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -5,12 +5,8 @@ version_info: https://github.com/Cloud-Native-Platform-Engineering/cnpe-communit
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers
 url: whitepapers/platforms
-versions:
-  - url: /whitepapers/platforms/
-    version: v1.1 (latest)
-    active: true
-  - url: /whitepapers/platforms/v1/
-    version: v1
+# Version switcher label, shown in every language.
+version_label: v1.1 (latest)
 ---
 
 ## Introduction

--- a/platforms-whitepaper/v1/index.md
+++ b/platforms-whitepaper/v1/index.md
@@ -11,12 +11,6 @@ url: whitepapers/platforms/v1
 list_pages: false
 # use toc_hide to hide this section from the sidebar
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: v1.1 (latest)
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---
 
 ## Introduction

--- a/website/content/de/resources/glossary/latest/index.md
+++ b/website/content/de/resources/glossary/latest/index.md
@@ -3,12 +3,6 @@ title: Glossar
 description: "Definiert Schlüsselbegriffe, die in den Texten der Arbeitsgruppe Plattformen verwendet werden."
 type: whitepapers
 url: resources/glossary
-versions:
-  - url: /resources/glossary/
-    version: latest
-    active: true
-  - url: /resources/glossary/v1/
-    version: v1
 ---
 
 Siehe auch: [Cloud Native Glossar](https://glossary.cncf.io/de/)

--- a/website/content/de/resources/glossary/v1/index.md
+++ b/website/content/de/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 toc_hide: true
 list_pages: false
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 Siehe auch: [Cloud Native Glossar](https://glossary.cncf.io/de/)

--- a/website/content/de/resources/maturity-model/latest/index.md
+++ b/website/content/de/resources/maturity-model/latest/index.md
@@ -1,0 +1,6 @@
+---
+title: "CNCF Platform Engineering Maturity Model"
+type: whitepapers
+url: whitepapers/platform-eng-maturity-model
+outdated: true
+---

--- a/website/content/de/resources/maturity-model/v1/index.md
+++ b/website/content/de/resources/maturity-model/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platform-eng-maturity-model/v1
 outdated: true
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/de/resources/whitepaper/latest/index.md
+++ b/website/content/de/resources/whitepaper/latest/index.md
@@ -3,10 +3,4 @@ title: "CNCF Platforms White Paper"
 type: whitepapers
 url: whitepapers/platforms
 outdated: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-    active: true
-  - url: /whitepapers/platforms/v1/
-    version: v1
 ---

--- a/website/content/de/resources/whitepaper/v1/index.md
+++ b/website/content/de/resources/whitepaper/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platforms/v1
 outdated: true
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/es/resources/glossary/v1/index.md
+++ b/website/content/es/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 Ver también: [Glosario Cloud Native](https://glossary.cncf.io/)

--- a/website/content/es/resources/maturity-model/latest/index.md
+++ b/website/content/es/resources/maturity-model/latest/index.md
@@ -8,12 +8,6 @@ Este documento refiere, amplía y sigue estándares similares a los siguientes d
 [Platforms Definition White Paper](/es/whitepapers/platforms/)"
 type: whitepapers
 url: whitepapers/platform-eng-maturity-model
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-    active: true
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
 ---
 
 

--- a/website/content/es/resources/maturity-model/v1/index.md
+++ b/website/content/es/resources/maturity-model/v1/index.md
@@ -10,12 +10,6 @@ type: whitepapers
 url: whitepapers/platform-eng-maturity-model/v1
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---
 
 

--- a/website/content/es/resources/whitepaper/latest/index.md
+++ b/website/content/es/resources/whitepaper/latest/index.md
@@ -3,10 +3,4 @@ title: "CNCF Platforms White Paper"
 type: whitepapers
 url: whitepapers/platforms
 outdated: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-    active: true
-  - url: /whitepapers/platforms/v1/
-    version: v1
 ---

--- a/website/content/es/resources/whitepaper/v1/index.md
+++ b/website/content/es/resources/whitepaper/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platforms/v1
 outdated: true
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/fr/resources/glossary/v1/index.md
+++ b/website/content/fr/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 Voir également : [Glossaire Cloud Native](https://glossary.cncf.io/fr/)

--- a/website/content/fr/resources/maturity-model/latest/index.md
+++ b/website/content/fr/resources/maturity-model/latest/index.md
@@ -1,0 +1,6 @@
+---
+title: "CNCF Platform Engineering Maturity Model"
+type: whitepapers
+url: whitepapers/platform-eng-maturity-model
+outdated: true
+---

--- a/website/content/fr/resources/maturity-model/v1/index.md
+++ b/website/content/fr/resources/maturity-model/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platform-eng-maturity-model/v1
 outdated: true
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/fr/resources/whitepaper/latest/index.md
+++ b/website/content/fr/resources/whitepaper/latest/index.md
@@ -3,10 +3,4 @@ title: "CNCF Platforms White Paper"
 type: whitepapers
 url: whitepapers/platforms
 outdated: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-    active: true
-  - url: /whitepapers/platforms/v1/
-    version: v1
 ---

--- a/website/content/fr/resources/whitepaper/v1/index.md
+++ b/website/content/fr/resources/whitepaper/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platforms/v1
 outdated: true
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/ja/resources/glossary/latest/index.md
+++ b/website/content/ja/resources/glossary/latest/index.md
@@ -3,12 +3,6 @@ title: 用語集
 description: "プラットフォームWGの文書で使用される主要な用語を定義します。"
 type: whitepapers
 url: resources/glossary
-versions:
-  - url: /resources/glossary/
-    version: latest
-    active: true
-  - url: /resources/glossary/v1/
-    version: v1
 ---
 
 [クラウドネイティブ用語集](https://glossary.cncf.io/ja/)も併せて参照してください。

--- a/website/content/ja/resources/glossary/v1/index.md
+++ b/website/content/ja/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 [クラウドネイティブ用語集](https://glossary.cncf.io/ja/)も併せて参照してください。

--- a/website/content/ja/resources/maturity-model/latest/index.md
+++ b/website/content/ja/resources/maturity-model/latest/index.md
@@ -8,12 +8,6 @@ description: "この成熟度モデルは、プラットフォームホワイト
 [プラットフォームホワイトペーパー](/whitepapers/platforms/)"
 type: whitepapers
 url: whitepapers/platform-eng-maturity-model
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-    active: true
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
 ---
 
 

--- a/website/content/ja/resources/maturity-model/v1/index.md
+++ b/website/content/ja/resources/maturity-model/v1/index.md
@@ -10,12 +10,6 @@ type: whitepapers
 url: whitepapers/platform-eng-maturity-model/v1
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---
 
 

--- a/website/content/ja/resources/whitepaper/latest/index.md
+++ b/website/content/ja/resources/whitepaper/latest/index.md
@@ -5,12 +5,6 @@ version_info: https://github.com/Cloud-Native-Platform-Engineering/cnpe-communit
 description: "この論文は、エンタープライズのリーダー、エンタープライズアーキテクト、およびプラットフォームチームのリーダーが、クラウドコンピューティングのための内部プラットフォームの提唱、調査、計画するのをサポートすることを目的としています。私たちは、プラットフォームが企業の実際のバリューストリームに大きな影響を与えると信じていますが、それは間接的なものなので、プラットフォームチームの長期的な持続と成功にはリーダーシップの合意と支援が不可欠です。この論文では、プラットフォームの価値が何であるか、それをどのように測定するか、そしてそれを最大化するプラットフォームチームをどのように実現するかについて議論することで、その支援を促進します。"
 type: whitepapers
 url: whitepapers/platforms
-versions:
-  - url: /ja/whitepapers/platforms/
-    version: v1.1 (latest)
-    active: true
-  - url: /ja/whitepapers/platforms/v1/
-    version: v1
 ---
 
 ## イントロダクション

--- a/website/content/ja/resources/whitepaper/v1/index.md
+++ b/website/content/ja/resources/whitepaper/v1/index.md
@@ -7,12 +7,6 @@ type: whitepapers
 url: whitepapers/platforms/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---
 
 ## イントロダクション

--- a/website/content/ko/resources/glossary/v1/index.md
+++ b/website/content/ko/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 [https://glossary.cncf.io/ ](https://glossary.cncf.io/) 참조

--- a/website/content/ko/resources/maturity-model/latest/index.md
+++ b/website/content/ko/resources/maturity-model/latest/index.md
@@ -1,0 +1,6 @@
+---
+title: "CNCF Platform Engineering Maturity Model"
+type: whitepapers
+url: whitepapers/platform-eng-maturity-model
+outdated: true
+---

--- a/website/content/ko/resources/maturity-model/v1/index.md
+++ b/website/content/ko/resources/maturity-model/v1/index.md
@@ -5,10 +5,4 @@ url: whitepapers/platform-eng-maturity-model/v1
 outdated: true
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---

--- a/website/content/ko/resources/whitepaper/v1/index.md
+++ b/website/content/ko/resources/whitepaper/v1/index.md
@@ -7,12 +7,6 @@ type: whitepapers
 url: whitepapers/platforms/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---
 
 ## 소개

--- a/website/content/zh/resources/glossary/v1/index.md
+++ b/website/content/zh/resources/glossary/v1/index.md
@@ -5,12 +5,6 @@ type: whitepapers
 url: resources/glossary/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /resources/glossary/
-    version: latest
-  - url: /resources/glossary/v1/
-    version: v1
-    active: true
 ---
 
 另可参考：[云原生术语表](https://glossary.cncf.io/)

--- a/website/content/zh/resources/maturity-model/latest/index.md
+++ b/website/content/zh/resources/maturity-model/latest/index.md
@@ -8,12 +8,6 @@ This document refers to, enhances, and follows similar standards as the followin
 [Platforms Definition White Paper](/zh/whitepapers/platforms/)"
 type: whitepapers
 url: whitepapers/platform-eng-maturity-model
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-    active: true
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
 ---
 
 

--- a/website/content/zh/resources/maturity-model/v1/index.md
+++ b/website/content/zh/resources/maturity-model/v1/index.md
@@ -10,12 +10,6 @@ type: whitepapers
 url: whitepapers/platform-eng-maturity-model/v1
 toc_hide: true
 list_pages: false
-versions:
-  - url: /whitepapers/platform-eng-maturity-model/
-    version: latest
-  - url: /whitepapers/platform-eng-maturity-model/v1/
-    version: v1
-    active: true
 ---
 
 

--- a/website/content/zh/resources/whitepaper/v1/index.md
+++ b/website/content/zh/resources/whitepaper/v1/index.md
@@ -7,12 +7,6 @@ type: whitepapers
 url: whitepapers/platforms/v1
 list_pages: false
 toc_hide: true
-versions:
-  - url: /whitepapers/platforms/
-    version: latest
-  - url: /whitepapers/platforms/v1/
-    version: v1
-    active: true
 ---
 
 ## 概述

--- a/website/layouts/partials/version-switcher.html
+++ b/website/layouts/partials/version-switcher.html
@@ -1,41 +1,66 @@
-{{ with .Params.versions }}
-{{/* Separate "latest" from versioned entries, sort versioned newest-first */}}
-{{ $latest := slice }}
-{{ $versioned := slice }}
-{{ range . }}
-  {{ if eq .version "latest" }}
-    {{ $latest = $latest | append . }}
-  {{ else }}
-    {{ $versioned = $versioned | append . }}
-  {{ end }}
-{{ end }}
-{{ $sorted := sort $versioned "version" "desc" }}
+{{/* The switcher lists the sibling latest/ v1/ v2/ ... directories in the
+     current language; the "latest" label is `version_label` on the English
+     page. */}}
 
-{{/* Determine the button label from the active entry */}}
-{{ $buttonLabel := "Version" }}
-{{ range . }}
-  {{ if .active }}
-    {{ if eq .version "latest" }}
-      {{ $buttonLabel = "Latest" }}
-    {{ else }}
-      {{ $buttonLabel = .version }}
+{{ if .File }}
+{{ $page := . }}
+{{ $docDir := path.Dir (strings.TrimSuffix "/" .File.Dir) }}
+
+{{ $latestItem := false }}
+{{ $versionedItems := slice }}
+
+{{/* whitepaper/ has no _index.md, so every document's versions share the
+     resources section; match on directory to pick out this one's. */}}
+{{ range .CurrentSection.Pages }}
+  {{ if .File }}
+    {{ $name := .File.ContentBaseName }}
+    {{ if and (eq (path.Dir (strings.TrimSuffix "/" .File.Dir)) $docDir) (findRE `^(latest|v[0-9])` $name) }}
+      {{ $item := dict "url" .RelPermalink "active" (eq .RelPermalink $page.RelPermalink) }}
+      {{ if eq $name "latest" }}
+        {{ $label := "Latest" }}
+        {{ with .Params.version_label }}{{ $label = . }}{{ end }}
+        {{ range .AllTranslations }}
+          {{ if eq .Language.Lang "en" }}
+            {{ with .Params.version_label }}{{ $label = . }}{{ end }}
+          {{ end }}
+        {{ end }}
+        {{ $latestItem = merge $item (dict "label" $label) }}
+      {{ else }}
+        {{/* Zero-padded sort key so v10 sorts above v9. Non-numeric parts fall
+             back to text, so an unexpected directory name orders oddly rather
+             than failing the build. */}}
+        {{ $parts := slice }}
+        {{ range split (strings.TrimPrefix "v" $name) "." }}
+          {{ if findRE `^[0-9]+$` . }}
+            {{ $parts = $parts | append (printf "%05d" (int .)) }}
+          {{ else }}
+            {{ $parts = $parts | append (printf "%5s" .) }}
+          {{ end }}
+        {{ end }}
+        {{ $versionedItems = $versionedItems | append (merge $item (dict "label" $name "key" (delimit $parts "."))) }}
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}
+
+{{/* The display order: latest first, then versioned items newest to oldest. */}}
+{{ $items := slice }}
+{{ with $latestItem }}{{ $items = $items | append . }}{{ end }}
+{{ range sort $versionedItems "key" "desc" }}{{ $items = $items | append . }}{{ end }}
+
+{{ if gt (len $items) 1 }}
+{{ $buttonLabel := "Version" }}
+{{ range $items }}{{ if .active }}{{ $buttonLabel = .label }}{{ end }}{{ end }}
 
 <div class="version-switcher dropdown d-inline-block mb-3">
   <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" id="versionSwitcher" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{ $buttonLabel }}
   </button>
   <div class="dropdown-menu" aria-labelledby="versionSwitcher">
-    {{/* Latest first */}}
-    {{ range $latest }}
-    <a class="dropdown-item{{ if .active }} active{{ end }}" href="{{ .url }}">Latest</a>
-    {{ end }}
-    {{/* Versioned entries, newest to oldest */}}
-    {{ range $sorted }}
-    <a class="dropdown-item{{ if .active }} active{{ end }}" href="{{ .url }}">{{ .version }}</a>
+    {{ range $items }}
+    <a class="dropdown-item{{ if .active }} active{{ end }}" href="{{ .url }}">{{ .label }}</a>
     {{ end }}
   </div>
 </div>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This updates the version-switcher logic to use the folder names with an optional metadata override, instead of manually specifying version data in each document.

to override version name details, use `version_label: "text"`